### PR TITLE
feat: use native AES on android

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,52 @@
+module.exports = {
+    "env": {
+        "browser": true,
+        "jasmine": true
+    },
+    "globals": {
+        "cordova": true,
+        "module": true,
+        "exports": true
+    },
+    "extends": "eslint:recommended",
+    "rules": {
+        "indent": [
+            "error",
+            4
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "quotes": [
+            "warn",
+            "single"
+        ],
+        "semi": [
+            "error",
+            "always"
+        ],
+        "no-console": [
+            "warn"
+        ],
+        "no-multi-spaces": [
+            "error"
+        ],
+        "eqeqeq": [
+            "error",
+            "smart"
+        ],
+        "no-loop-func": [
+            "error"
+        ],
+        "no-param-reassign": [
+            "error"
+        ],
+        "vars-on-top": [
+            "warn"
+        ],
+        "no-use-before-define": [
+            "error"
+        ],
+    }
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "Secure storage plugin for iOS & Android",
   "author": "Yiorgis Gozadinos <ggozad@crypho.com>",
   "contributors": [
-    {"name": "Demetris Manikas", "email": "demetris.manikas@gmail.com"}
+    {
+      "name": "Demetris Manikas",
+      "email": "demetris.manikas@gmail.com"
+    }
   ],
   "cordova": {
     "id": "cordova-plugin-secure-storage",
@@ -28,8 +31,12 @@
     "type": "git",
     "url": "git+https://github.com/crypho/cordova-plugin-secure-storage.git"
   },
+  "scripts": {
+    "eslint": "./node_modules/.bin/eslint www/securestorage.js tests/tests.js"
+  },
   "devDependencies": {
-    "cordova-plugin-test-framework": ">=1.0.0"
+    "cordova-plugin-test-framework": ">=1.0.0",
+    "eslint": ""
   },
   "license": "MIT",
   "bugs": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -54,6 +54,7 @@
 
         <source-file src="src/android/SecureStorage.java" target-dir="src/com/crypho/plugins/" />
         <source-file src="src/android/RSA.java" target-dir="src/com/crypho/plugins/" />
+        <source-file src="src/android/AES.java" target-dir="src/com/crypho/plugins/" />
     </platform>
 
     <platform name="browser">

--- a/src/android/AES.java
+++ b/src/android/AES.java
@@ -24,7 +24,7 @@ public class AES {
 	public static JSONObject encrypt(Cipher encKeyCipher, byte[] msg, byte[] adata) throws Exception {
 		SecretKeySpec secretKeySpec = generateKeySpec();
 		byte[] encryptedKey = encKeyCipher.doFinal(secretKeySpec.getEncoded());
-		Cipher cipher = createCipher(Cipher.ENCRYPT_MODE, secretKeySpec, adata, null);
+		Cipher cipher = createCipher(Cipher.ENCRYPT_MODE, secretKeySpec, null, adata);
 		byte[] iv = cipher.getIV();
 
 		JSONObject value = new JSONObject();
@@ -46,7 +46,7 @@ public class AES {
 
 	public static String decrypt(byte[] buf, byte[] key, byte[] iv, byte[] adata) throws Exception {
 		SecretKeySpec secretKeySpec = new SecretKeySpec(key, "AES");
-		Cipher cipher = createCipher(Cipher.DECRYPT_MODE, secretKeySpec, adata, new IvParameterSpec(iv));
+		Cipher cipher = createCipher(Cipher.DECRYPT_MODE, secretKeySpec, iv, adata);
 		return new String(cipher.doFinal(buf));
 	}
 
@@ -57,10 +57,10 @@ public class AES {
 	    return new SecretKeySpec(sc.getEncoded(), "AES");
 	}
 
-	private static Cipher createCipher(int cipherMode, Key key, byte[] adata, IvParameterSpec iv) throws Exception {
+	private static Cipher createCipher(int cipherMode, Key key, byte[] iv, byte[] adata) throws Exception {
 		Cipher cipher = Cipher.getInstance(CIPHER);
 		if (iv != null) {
-			cipher.init(cipherMode, key, iv);
+			cipher.init(cipherMode, key, new IvParameterSpec(iv));
 		} else {
 			cipher.init(cipherMode, key);
 		}

--- a/src/android/AES.java
+++ b/src/android/AES.java
@@ -1,0 +1,75 @@
+package com.crypho.plugins;
+
+import android.util.Log;
+import android.util.Base64;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.security.Key;
+import java.security.SecureRandom;
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.KeyGenerator;
+
+public class AES {
+	private static final int VERSION_1 = 1;
+
+	private static final int IV_SIZE = 12;
+	private static final String CIPHER = "AES/CCM/NoPadding";
+	private static final int KEY_SIZE = 256;
+
+	private static final int VERSION = VERSION_1;
+
+	public static JSONObject encrypt(Cipher encKeyCipher, byte[] msg, byte[] adata) throws Exception {
+		SecretKeySpec secretKeySpec = generateKeySpec();
+		byte[] encryptedKey = encKeyCipher.doFinal(secretKeySpec.getEncoded());
+		byte[] iv = generateIV(IV_SIZE);
+		Cipher cipher = createCipher(Cipher.ENCRYPT_MODE, secretKeySpec, new IvParameterSpec(iv));
+		cipher.updateAAD(adata);
+
+		JSONObject value = new JSONObject();
+		value.put("iv", Base64.encodeToString(iv, Base64.DEFAULT));
+		value.put("v", Integer.toString(VERSION));
+		value.put("ks", Integer.toString(KEY_SIZE));
+		value.put("cipher", "aes");
+		value.put("adata", Base64.encodeToString(adata, Base64.DEFAULT));
+		value.put("ct", Base64.encodeToString(cipher.doFinal(msg), Base64.DEFAULT));
+
+		JSONObject result = new JSONObject();
+		result.put("key", Base64.encodeToString(encryptedKey, Base64.DEFAULT));
+		result.put("value", value);
+		result.put("native", true);
+
+		return result;
+	}
+
+	public static String decrypt(byte[] buf, byte[] key, byte[] iv, byte[] adata) throws Exception {
+		SecretKeySpec secretKeySpec = new SecretKeySpec(key, "AES");
+		Cipher cipher = createCipher(Cipher.DECRYPT_MODE, secretKeySpec, new IvParameterSpec(iv));
+		cipher.updateAAD(adata);
+		return new String(cipher.doFinal(buf));
+	}
+
+	private static SecretKeySpec generateKeySpec() throws Exception {
+	    KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
+	    keyGenerator.init(KEY_SIZE, new SecureRandom());
+	    SecretKey sc = keyGenerator.generateKey();
+	    return new SecretKeySpec(sc.getEncoded(), "AES");
+	}
+
+	private static Cipher createCipher(int cipherMode, Key key, IvParameterSpec iv) throws Exception {
+		Cipher cipher = Cipher.getInstance(CIPHER);
+		cipher.init(cipherMode, key, iv);
+		return cipher;
+	}
+
+	private static byte[] generateIV(int size) {
+		byte[] iv = new byte[size];
+		SecureRandom sr = new SecureRandom();
+		sr.nextBytes(iv);
+		return iv;
+	}
+}

--- a/src/android/SecureStorage.java
+++ b/src/android/SecureStorage.java
@@ -2,7 +2,7 @@ package com.crypho.plugins;
 
 import android.util.Log;
 import android.util.Base64;
-
+import android.os.Build;
 import android.content.Context;
 import android.content.Intent;
 
@@ -17,6 +17,7 @@ public class SecureStorage extends CordovaPlugin {
     private static final String TAG = "SecureStorage";
 
     private String ALIAS;
+    private int SUPPORTS_NATIVE_AES;
     private volatile CallbackContext initContext;
     private volatile boolean initContextRunning = false;
 
@@ -30,7 +31,7 @@ public class SecureStorage extends CordovaPlugin {
                         if (!RSA.isEntryAvailable(ALIAS)) {
                             RSA.createKeyPair(getContext(), ALIAS);
                         }
-                        initContext.success();
+                        initContext.success(SUPPORTS_NATIVE_AES);
                     } catch (Exception e) {
                         Log.e(TAG, "Init failed :", e);
                         initContext.error(e.getMessage());
@@ -46,12 +47,14 @@ public class SecureStorage extends CordovaPlugin {
     @Override
     public boolean execute(String action, CordovaArgs args, final CallbackContext callbackContext) throws JSONException {
         if ("init".equals(action)) {
+            // 0 is falsy in js while 1 is truthy
+            SUPPORTS_NATIVE_AES = Build.VERSION.SDK_INT >= 21 ? 1 : 0;
             ALIAS = getContext().getPackageName() + "." + args.getString(0);
             if (!RSA.isEntryAvailable(ALIAS)) {
                 initContext = callbackContext;
                 unlockCredentials();
             } else {
-                callbackContext.success();
+                callbackContext.success(SUPPORTS_NATIVE_AES);
             }
             return true;
         }
@@ -66,7 +69,7 @@ public class SecureStorage extends CordovaPlugin {
                         JSONObject result = AES.encrypt(encKeyCipher, encryptMe.getBytes(), adata.getBytes());
                         callbackContext.success(result);
                     } catch (Exception e) {
-                        Log.e(TAG, "Encrypt failed :", e);
+                        Log.e(TAG, "Encrypt (RSA/AES) failed :", e);
                         callbackContext.error(e.getMessage());
                     }
                 }
@@ -86,14 +89,14 @@ public class SecureStorage extends CordovaPlugin {
                         String decrypted = new String(AES.decrypt(ct, key, iv, adata));
                         callbackContext.success(decrypted);
                     } catch (Exception e) {
-                        Log.e(TAG, "Decrypt failed :", e);
+                        Log.e(TAG, "Decrypt (RSA/AES) failed :", e);
                         callbackContext.error(e.getMessage());
                     }
                 }
             });
             return true;
         }
-        if ("decrypt_dsa".equals(action)) {
+        if ("decrypt_rsa".equals(action)) {
             // getArrayBuffer does base64 decoding
             final byte[] decryptMe = args.getArrayBuffer(0);
             cordova.getThreadPool().execute(new Runnable() {
@@ -102,14 +105,28 @@ public class SecureStorage extends CordovaPlugin {
                         byte[] decrypted = RSA.decrypt(decryptMe, ALIAS);
                         callbackContext.success(new String (decrypted));
                     } catch (Exception e) {
-                        Log.e(TAG, "Decrypt failed :", e);
+                        Log.e(TAG, "Decrypt (RSA) failed :", e);
                         callbackContext.error(e.getMessage());
                     }
                 }
             });
             return true;
         }
-
+        if ("encrypt_rsa".equals(action)) {
+            final String encryptMe = args.getString(0);
+            cordova.getThreadPool().execute(new Runnable() {
+                public void run() {
+                    try {
+                        byte[] encrypted = RSA.encrypt(encryptMe.getBytes(), ALIAS);
+                        callbackContext.success(Base64.encodeToString(encrypted, Base64.DEFAULT));
+                    } catch (Exception e) {
+                        Log.e(TAG, "Encrypt (RSA) failed :", e);
+                        callbackContext.error(e.getMessage());
+                    }
+                }
+            });
+            return true;
+        }
         return false;
     }
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -92,7 +92,6 @@ exports.defineAutoTests = function() {
                 ss.remove(handlers.successHandler, handlers.errorHandler, 'foo');
             }, handlers.errorHandler, 'testing');
         });
-
         it('should be able to set and retrieve multiple values in sequence', function (done) {
             var results = [];
             spyOn(handlers, 'successHandler').and.callFake(function (res) {
@@ -111,6 +110,5 @@ exports.defineAutoTests = function() {
                 }, function () {}, 'foo', 'foo');
             }, handlers.errorHandler, 'testing');
         });
-
     });
 };

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -100,7 +100,7 @@ exports.defineAutoTests = function() {
                     done();
                 }
             });
-            ss = new cordova.plugins.SecureStorage(function (res) {
+            ss = new cordova.plugins.SecureStorage(function () {
                 ss.set(function () {
                     ss.set(function () {
                         ss.get(handlers.successHandler, handlers.errorHandler, 'foo');
@@ -131,7 +131,11 @@ exports.defineAutoTests = function() {
 
                 ss = new cordova.plugins.SecureStorage(function () {
                     ss.set(handlers.successHandler, handlers.errorHandler, 'foo', 'bar');
-                }, handlers.errorHandler, SERVICE, true);
+                },
+                handlers.errorHandler,
+                SERVICE,
+                {native: false}
+                );
             });
 
             it('should be able to get a key/value that was set before with sjcl', function (done) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,30 +1,29 @@
 exports.defineAutoTests = function() {
+    var ss, handlers;
+    var SERVICE = 'testing';
 
     describe('cordova-plugin-secure-storage', function () {
 
-        var ss, successHandler, errorHandler, handlers;
-
         beforeEach(function () {
             handlers = {
-                successHandler: function (res) {
-                },
-                errorHandler: function (err) {
-                }};
+                successHandler: function () {},
+                errorHandler: function () {}
+            };
         });
 
-        it("should be defined", function() {
+        it('should be defined', function() {
             expect(cordova.plugins.SecureStorage).toBeDefined();
         });
 
         it('should be able to initialize', function (done) {
             spyOn(handlers, 'successHandler').and.callFake(function () {
-                expect(ss.service).toEqual('testing');
+                expect(ss.service).toEqual(SERVICE);
                 expect(handlers.errorHandler).not.toHaveBeenCalled();
                 done();
             });
             spyOn(handlers, 'errorHandler');
 
-            ss = new cordova.plugins.SecureStorage(handlers.successHandler, handlers.errorHandler, 'testing');
+            ss = new cordova.plugins.SecureStorage(handlers.successHandler, handlers.errorHandler, SERVICE);
         });
 
         it('should be able to set a key/value', function (done) {
@@ -35,9 +34,9 @@ exports.defineAutoTests = function() {
             });
             spyOn(handlers, 'errorHandler');
 
-            ss = new cordova.plugins.SecureStorage(function (res) {
+            ss = new cordova.plugins.SecureStorage(function () {
                 ss.set(handlers.successHandler, handlers.errorHandler, 'foo', 'bar');
-            }, handlers.errorHandler, 'testing');
+            }, handlers.errorHandler, SERVICE);
         });
 
         it('should be able to get a key/value', function (done) {
@@ -48,11 +47,11 @@ exports.defineAutoTests = function() {
             });
             spyOn(handlers, 'errorHandler');
 
-            ss = new cordova.plugins.SecureStorage(function (res) {
+            ss = new cordova.plugins.SecureStorage(function () {
                 ss.set(function () {
                     ss.get(handlers.successHandler, handlers.errorHandler, 'foo');
                 }, handlers.errorHandler, 'foo', 'bar');
-            }, handlers.errorHandler, 'testing');
+            }, handlers.errorHandler, SERVICE);
         });
 
         it('should be able to get a key/value that was set before', function (done) {
@@ -63,21 +62,21 @@ exports.defineAutoTests = function() {
             });
             spyOn(handlers, 'errorHandler');
 
-            ss = new cordova.plugins.SecureStorage(function (res) {
+            ss = new cordova.plugins.SecureStorage(function () {
                 ss.get(handlers.successHandler, handlers.errorHandler, 'foo');
-            }, handlers.errorHandler, 'testing');
+            }, handlers.errorHandler, SERVICE);
         });
 
         it('should call the error handler when getting a key that does not exist', function (done) {
-            spyOn(handlers, 'errorHandler').and.callFake(function (res) {
+            spyOn(handlers, 'errorHandler').and.callFake(function () {
                 expect(handlers.successHandler).not.toHaveBeenCalled();
                 done();
             });
             spyOn(handlers, 'successHandler');
 
-            ss = new cordova.plugins.SecureStorage(function (res) {
+            ss = new cordova.plugins.SecureStorage(function () {
                 ss.get(handlers.successHandler, handlers.errorHandler, 'nofoo');
-            }, handlers.errorHandler, 'testing');
+            }, handlers.errorHandler, SERVICE);
         });
 
         it('should be able to remove a key/value', function (done) {
@@ -88,9 +87,9 @@ exports.defineAutoTests = function() {
             });
             spyOn(handlers, 'errorHandler');
 
-            ss = new cordova.plugins.SecureStorage(function (res) {
+            ss = new cordova.plugins.SecureStorage(function () {
                 ss.remove(handlers.successHandler, handlers.errorHandler, 'foo');
-            }, handlers.errorHandler, 'testing');
+            }, handlers.errorHandler, SERVICE);
         });
         it('should be able to set and retrieve multiple values in sequence', function (done) {
             var results = [];
@@ -111,4 +110,43 @@ exports.defineAutoTests = function() {
             }, handlers.errorHandler, 'testing');
         });
     });
+
+    if (cordova.platformId === 'android') {
+        describe('cordova-plugin-secure-storage-android', function () {
+            beforeEach(function () {
+                handlers = {
+                    successHandler: function () {},
+                    errorHandler: function () {}
+                };
+            });
+
+            it('should be able to set a key/value with sjcl', function (done) {
+                localStorage.clear();
+                spyOn(handlers, 'successHandler').and.callFake(function (res) {
+                    expect(res).toEqual('foo');
+                    expect(handlers.errorHandler).not.toHaveBeenCalled();
+                    done();
+                });
+                spyOn(handlers, 'errorHandler');
+
+                ss = new cordova.plugins.SecureStorage(function () {
+                    ss.set(handlers.successHandler, handlers.errorHandler, 'foo', 'bar');
+                }, handlers.errorHandler, SERVICE, true);
+            });
+
+            it('should be able to get a key/value that was set before with sjcl', function (done) {
+                spyOn(handlers, 'successHandler').and.callFake(function (res) {
+                    expect(res).toEqual('bar');
+                    expect(handlers.errorHandler).not.toHaveBeenCalled();
+                    done();
+                });
+                spyOn(handlers, 'errorHandler');
+
+                ss = new cordova.plugins.SecureStorage(function () {
+                    ss.get(handlers.successHandler, handlers.errorHandler, 'foo');
+                }, handlers.errorHandler, SERVICE);
+            });
+
+        });
+    }
 };

--- a/www/securestorage.js
+++ b/www/securestorage.js
@@ -1,111 +1,268 @@
+var SecureStorage, SecureStorageiOS, SecureStorageAndroid, SecureStorageBrowser;
 var sjcl_ss = cordova.require('cordova-plugin-secure-storage.sjcl_ss');
-
-var _checkCallbacks = function (success, error) {
-
-    if (typeof success != "function")  {
-        console.log("SecureStorage failure: success callback parameter must be a function");
-        return false;
-    }
-
-    if (typeof error != "function") {
-        console.log("SecureStorage failure: error callback parameter must be a function");
-        return false;
-    }
-
-    return true;
+var _AES_PARAM = {
+    ks: 256,
+    ts: 128,
+    mode: 'ccm',
+    cipher: 'aes'
 };
 
-var SecureStorageiOS = function (success, error, service) {
+var _checkCallbacks = function (success, error) {
+    if (typeof success != 'function') {
+        throw new Error('SecureStorage failure: success callback parameter must be a function');
+    }
+    if (typeof error != 'function') {
+        throw new Error('SecureStorage failure: error callback parameter must be a function');
+    }
+};
+
+SecureStorageiOS = function (success, error, service) {
     this.service = service;
     setTimeout(success, 0);
     return this;
 };
 
 SecureStorageiOS.prototype = {
-
     get: function (success, error, key) {
-        if (_checkCallbacks(success, error))
-            cordova.exec(success, error, "SecureStorage", "get", [this.service, key]);
-    },
-
-    set: function (success, error, key, value) {
-        if (_checkCallbacks(success, error))
-            cordova.exec(success, error, "SecureStorage", "set", [this.service, key, value]);
-    },
-
-    remove: function(success, error, key) {
-        if (_checkCallbacks(success, error))
-            cordova.exec(success, error, "SecureStorage", "remove", [this.service, key]);
-    }
-};
-
-var SecureStorageAndroid = function (success, error, service) {
-    this.service = service;
-    cordova.exec(success, error, "SecureStorage", "init", [this.service]);
-    return this;
-};
-
-SecureStorageAndroid.prototype = {
-
-    get: function (success, error, key) {
-        if (!_checkCallbacks(success, error)) {
-           return;
-        }
-        var payload = localStorage.getItem('_SS_' + key);
-        if (!payload) {
-            error('Key "' + key + '" not found.');
-            return;
-        }
         try {
-            payload = JSON.parse(payload);
-            if (payload.native) {
-                var AESkey = payload.key;
-                var value = payload.value;
-                var ct = value.ct;
-                var iv = value.iv;
-                var adata = value.adata;
-                cordova.exec(success, error, "SecureStorage", "decrypt", [AESkey, ct, iv, adata]);
-            } else {
-                cordova.exec(
-                    function (AESKey) {
-                        try {
-                            AESKey = sjcl_ss.codec.base64.toBits(AESKey);
-                            var value = sjcl_ss.decrypt(AESKey, payload.value);
-                            success(value);
-                        } catch (e) {
-                            error(e);
-                        }
-                    },
-                    error, "SecureStorage", "decrypt_dsa", [AESKey]);
-            }
+            _checkCallbacks(success, error);
+            cordova.exec(success, error, 'SecureStorage', 'get', [this.service, key]);
         } catch (e) {
             error(e);
         }
     },
 
     set: function (success, error, key, value) {
-        if (!_checkCallbacks(success, error)){
-            return;
+        try {
+            _checkCallbacks(success, error);
+            cordova.exec(success, error, 'SecureStorage', 'set', [this.service, key, value]);
+        } catch (e) {
+            error(e);
         }
-        cordova.exec(
-            function (result) {
-                localStorage.setItem('_SS_' + key, JSON.stringify(result));
-                success(key);
-            },
-            function (err) {
-                error(err);
-            },
-            "SecureStorage", "encrypt", [value, this.service]);
     },
 
-    remove: function(success, error, key) {
-        localStorage.removeItem('_SS_' + key);
-        success(key);
+    remove: function (success, error, key) {
+        try {
+            _checkCallbacks(success, error);
+            cordova.exec(success, error, 'SecureStorage', 'remove', [this.service, key]);
+        } catch (e) {
+            error(e);
+        }
     }
 };
 
+SecureStorageAndroid = function (success, error, service, _use_sjcl) {
+    var self = this;
+    var migrated;
 
-var SecureStorageBrowser = function (success, error, service) {
+    this.service = service;
+    try {
+        _checkCallbacks(success, error);
+        cordova.exec(
+            function (native_aes_supported) {
+                if (!native_aes_supported || _use_sjcl) {
+                    self.USE_NATIVE_AES = false;
+                    success();
+                } else {
+                    self.USE_NATIVE_AES = native_aes_supported;
+                    migrated = localStorage.getItem('_SS_MIGRATED_TO_NATIVE');
+                    if (self.USE_NATIVE_AES && !migrated) {
+                        self._migrate_to_native(success);
+                    } else {
+                        success();
+                    }
+                }
+            },
+            error,
+            'SecureStorage',
+            'init',
+            [this.service]
+        );
+    } catch (e) {
+        error(e);
+    }
+    return this;
+};
+
+SecureStorageAndroid.prototype = {
+
+    get: function (success, error, key) {
+        if (!this.USE_NATIVE_AES) {
+            this._sjcl_get(success, error, key);
+        } else {
+            this._native_get(success, error, key);
+        }
+    },
+
+    set: function (success, error, key, value) {
+        if (!this.USE_NATIVE_AES) {
+            this._sjcl_set(success, error, key, value);
+        } else {
+            this._native_set(success, error, key, value);
+        }
+    },
+
+    remove: function (success, error, key) {
+        localStorage.removeItem('_SS_' + key);
+        success(key);
+    },
+
+    _sjcl_get: function (success, error, key) {
+        var payload, encAESKey;
+
+        try {
+            _checkCallbacks(success, error);
+            payload = this._get_payload(key);
+            encAESKey = payload.key;
+            cordova.exec(
+                function (AESKey) {
+                    var value, AESKeyBits;
+                    try {
+                        AESKeyBits = sjcl_ss.codec.base64.toBits(AESKey);
+                        value = sjcl_ss.decrypt(AESKeyBits, payload.value);
+                        success(value);
+                    } catch (e) {
+                        error(e);
+                    }
+                },
+                error,
+                'SecureStorage',
+                'decrypt_rsa',
+                [encAESKey]
+            );
+        } catch (e) {
+            error(e);
+        }
+    },
+
+    _sjcl_set: function (success, error, key, value) {
+        var AESKey, encValue;
+
+        try {
+            _checkCallbacks(success, error);
+            AESKey = sjcl_ss.random.randomWords(8);
+            _AES_PARAM.adata = this.service;
+            encValue = sjcl_ss.encrypt(AESKey, value, _AES_PARAM);
+            // Encrypt the AES key
+            cordova.exec(
+                function (encKey) {
+                    localStorage.setItem('_SS_' + key, JSON.stringify({key: encKey, value: encValue}));
+                    success(key);
+                },
+                error,
+                'SecureStorage',
+                'encrypt_rsa',
+                [sjcl_ss.codec.base64.fromBits(AESKey)]
+            );
+        } catch (e) {
+            error(e);
+        }
+    },
+
+    _native_get: function (success, error, key) {
+        var payload, AESkey, value;
+
+        try {
+            _checkCallbacks(success, error);
+            payload = this._get_payload(key);
+            AESkey = payload.key;
+            value = payload.value;
+            cordova.exec(
+                success,
+                error,
+                'SecureStorage',
+                'decrypt',
+                [AESkey, value.ct, value.iv, value.adata]
+            );
+        } catch (e) {
+            error(e);
+        }
+    },
+
+    _native_set: function (success, error, key, value) {
+        try {
+            _checkCallbacks(success, error);
+            cordova.exec(
+                function (result) {
+                    localStorage.setItem('_SS_' + key, JSON.stringify(result));
+                    success(key);
+                },
+                error,
+                'SecureStorage',
+                'encrypt',
+                [value, this.service]
+            );
+        } catch (e) {
+            error(e);
+        }
+    },
+
+    _get_payload: function (key) {
+        var payload = localStorage.getItem('_SS_' + key);
+
+        if (!payload) {
+            throw new Error('Key "' + key + '" not found.');
+        }
+        return JSON.parse(payload);
+    },
+
+    _migrate_to_native: function (success) {
+        var keysLeft, payload, i, key, migrated, sjcl_get_success, sjcl_get_error;
+        var self = this;
+        var migrateKeys = [];
+
+        migrated = function () {
+            localStorage.setItem('_SS_MIGRATED_TO_NATIVE', '1');
+            success();
+        };
+
+        for (key in localStorage) {
+            if (localStorage.hasOwnProperty(key)) {
+                if (key.startsWith('_SS_')) {
+                    payload = JSON.parse(localStorage.getItem(key));
+                    //Just in case init was interrupted and rerun
+                    if (!payload.native) {
+                        migrateKeys.push(key.replace('_SS_', ''));
+                    }
+                }
+            }
+        }
+
+        if (migrateKeys.length === 0) {
+            migrated();
+            return;
+        }
+
+        sjcl_get_success = function (value) {
+            self._native_set(
+                function (key) {
+                    //Remove processed key
+                    keysLeft.splice(keysLeft.indexOf(key), 1);
+                    if (keysLeft.length === 0) {
+                        migrated();
+                    }
+                },
+                function () {},
+                key,
+                value
+            );
+        };
+
+        sjcl_get_error = function () {};
+
+        keysLeft = migrateKeys.slice();
+        for (i = 0; i < migrateKeys.length; i++) {
+            key = migrateKeys[i];
+            this._sjcl_get(
+                sjcl_get_success,
+                sjcl_get_error,
+                key
+            );
+        }
+    }
+};
+
+SecureStorageBrowser = function (success, error, service) {
     this.service = service;
     setTimeout(success, 0);
     return this;
@@ -114,50 +271,47 @@ var SecureStorageBrowser = function (success, error, service) {
 SecureStorageBrowser.prototype = {
 
     get: function (success, error, key) {
-        if (!_checkCallbacks(success, error))
-            return;
-        var value = localStorage.getItem('_SS_' + key);
-        if (!value) {
-            error('Key "' + key + '"not found.');
-        } else {
-            success(value);
+        var value;
+        try {
+            _checkCallbacks(success, error);
+            value = localStorage.getItem('_SS_' + key);
+            if (!value) {
+                error('Key "' + key + '"not found.');
+            } else {
+                success(value);
+            }
+        } catch (e) {
+            error(e);
         }
     },
 
     set: function (success, error, key, value) {
-        if (!_checkCallbacks(success, error))
-            return;
-
-        localStorage.setItem('_SS_' + key, value);
-        success(key);
+        try {
+            _checkCallbacks(success, error);
+            localStorage.setItem('_SS_' + key, value);
+            success(key);
+        } catch (e) {
+            error(e);
+        }
     },
-
-    remove: function(success, error, key) {
+    remove: function (success, error, key) {
         localStorage.removeItem('_SS_' + key);
         success(key);
     }
 };
 
-
-
-var SecureStorage;
-
-switch(cordova.platformId) {
-
-    case 'ios':
-        SecureStorage = SecureStorageiOS;
-        break;
-
-    case 'android':
-        SecureStorage = SecureStorageAndroid;
-        break;
-
-    case 'browser':
-        SecureStorage = SecureStorageBrowser;
-        break;
-
-    default:
-        SecureStorage = null;
+switch (cordova.platformId) {
+case 'ios':
+    SecureStorage = SecureStorageiOS;
+    break;
+case 'android':
+    SecureStorage = SecureStorageAndroid;
+    break;
+case 'browser':
+    SecureStorage = SecureStorageBrowser;
+    break;
+default:
+    SecureStorage = null;
 }
 
 if (!cordova.plugins) {
@@ -169,5 +323,5 @@ if (!cordova.plugins.SecureStorage) {
 }
 
 if (typeof module != 'undefined' && module.exports) {
-  module.exports = SecureStorage;
+    module.exports = SecureStorage;
 }


### PR DESCRIPTION
NOTICE: This implementation is not compatible with the current one.

I tried decrypting the sjcl created ciphers to no avail. I faced the same problem as described in 
http://stackoverflow.com/questions/36461881/decrypting-aes-256-ccm-with-16byte-initial-vector-encrypted-by-sjcl
Solution given was to tag the natively produced payloads and use the sjcl decryption mechanism when the payload is not tagged as native. 
The only problem that remains is testability of the old implementation.
I 'll try to figure out some way to do it but any ideas are welcome.
Cheers
